### PR TITLE
Docker initial load packages in editor

### DIFF
--- a/web_ui/app/editor/page.tsx
+++ b/web_ui/app/editor/page.tsx
@@ -1,6 +1,7 @@
 import { EditorClient } from '@/features/editor/components/EditorClient';
 import { getTaskSpecs, getLabSpecs } from '@/lib/api/specs';
-import type { Package, EntityType } from '@/lib/types/filesystem';
+import { scanPackages } from '@/lib/filesystem/operations';
+import type { EntityType } from '@/lib/types/filesystem';
 import type { ParameterSpec } from '@/lib/types/protocol';
 
 export const dynamic = 'force-dynamic';
@@ -9,25 +10,6 @@ export const metadata = {
   title: 'Editor',
   description: 'Edit EOS packages, protocols, devices, tasks, and labs',
 };
-
-async function getPackages(): Promise<Package[]> {
-  try {
-    const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
-    const response = await fetch(`${baseUrl}/api/filesystem/packages`, {
-      cache: 'no-store',
-    });
-
-    if (!response.ok) {
-      console.error('Failed to fetch packages:', response.statusText);
-      return [];
-    }
-
-    return response.json();
-  } catch (error) {
-    console.error('Error fetching packages:', error);
-    return [];
-  }
-}
 
 interface EditorPageProps {
   searchParams: Promise<{
@@ -43,7 +25,7 @@ export default async function EditorPage({ searchParams }: EditorPageProps) {
   const params = await searchParams;
 
   // Fetch packages and specs in parallel
-  const [packages, taskSpecs, labSpecs] = await Promise.all([getPackages(), getTaskSpecs(), getLabSpecs()]);
+  const [packages, taskSpecs, labSpecs] = await Promise.all([scanPackages(), getTaskSpecs(), getLabSpecs()]);
 
   // Transform task specs for protocol editor (keep existing logic)
   const taskSpecsArray = Object.entries(taskSpecs).map(([type, spec]) => {

--- a/web_ui/features/editor/components/PackageFileTree.tsx
+++ b/web_ui/features/editor/components/PackageFileTree.tsx
@@ -301,7 +301,7 @@ interface PackageNodeProps {
   renameValue: string;
   creatingEntity: { packageName: string; entityType: EntityType } | null;
   newEntityName: string;
-  getEntityTree: (packageName: string) => EntityTree | undefined;
+  entityTrees: Record<string, EntityTree>;
   onTogglePackage: (packageName: string) => void;
   onToggleEntityType: (key: string) => void;
   onCreateStart: (packageName: string, entityType: EntityType) => void;
@@ -312,7 +312,7 @@ interface PackageNodeProps {
   onRenameConfirm: () => void;
   onRenameCancel: () => void;
   onEntityClick: (packageName: string, entityType: EntityType, entityName: string) => void;
-  onContextMenu: (e: React.MouseEvent, packageName: string, entityType: EntityType, entityName: string) => void;
+  onContextMenu: (e: React.MouseEvent, packageName: string, entityType: EntityType, entityName?: string) => void;
   onDeleteRequest: (packageName: string, entityType: EntityType, entityName: string) => void;
 }
 
@@ -329,7 +329,7 @@ function PackageNode({
   renameValue,
   creatingEntity,
   newEntityName,
-  getEntityTree,
+  entityTrees,
   onTogglePackage,
   onToggleEntityType,
   onCreateStart,
@@ -343,7 +343,7 @@ function PackageNode({
   onContextMenu,
   onDeleteRequest,
 }: PackageNodeProps) {
-  const entityTree = isExpanded ? getEntityTree(pkg.name) : null;
+  const entityTree = isExpanded ? entityTrees[pkg.name] : null;
 
   return (
     <div className="mb-1">
@@ -419,7 +419,7 @@ interface PackageFileTreeProps {
   onDeleteEntity: (packageName: string, entityType: EntityType, entityName: string) => void;
   onRenameEntity: (packageName: string, entityType: EntityType, oldName: string, newName: string) => void;
   onRefresh?: () => void;
-  onPackageExpand: (packageName: string) => void;
+  onPackageExpand: (packageName: string) => Promise<void>;
 }
 
 export function PackageFileTree({
@@ -433,7 +433,7 @@ export function PackageFileTree({
   const selectedPackage = useEditorStore((state) => state.selectedPackage);
   const selectedEntityType = useEditorStore((state) => state.selectedEntityType);
   const selectedEntityName = useEditorStore((state) => state.selectedEntityName);
-  const getEntityTree = useEditorStore((state) => state.getEntityTree);
+  const entityTrees = useEditorStore((state) => state.entityTrees);
   const selectEntity = useEditorStore((state) => state.selectEntity);
   const cache = useEditorStore((state) => state.cache);
 
@@ -499,9 +499,19 @@ export function PackageFileTree({
 
   // Fetch entity trees for all packages on mount
   useEffect(() => {
-    packages.forEach((pkg) => {
-      onPackageExpand(pkg.name);
-    });
+    const loadEntityTrees = async () => {
+      for (const pkg of packages) {
+        await onPackageExpand(pkg.name);
+      }
+      // Auto-expand packages if none are expanded
+      setExpandedPackages((prev) => {
+        if (prev.size === 0) {
+          return new Set(packages.map(p => p.name));
+        }
+        return prev;
+      });
+    };
+    loadEntityTrees();
   }, [packages, onPackageExpand]);
 
   const togglePackage = useCallback(
@@ -634,7 +644,7 @@ export function PackageFileTree({
     const filtered: FilteredPackage[] = [];
 
     packages.forEach((pkg) => {
-      const entityTree = getEntityTree(pkg.name);
+      const entityTree = entityTrees[pkg.name];
       if (!entityTree) return;
 
       const matchingTypes: Partial<Record<EntityType, EntityNode[]>> = {};
@@ -658,7 +668,7 @@ export function PackageFileTree({
     });
 
     return filtered;
-  }, [debouncedQuery, packages, getEntityTree]);
+  }, [debouncedQuery, packages, entityTrees]);
 
   // Auto-expand packages and entity types when searching
   useEffect(() => {
@@ -772,7 +782,7 @@ export function PackageFileTree({
               renameValue={renameValue}
               creatingEntity={creatingEntity}
               newEntityName={newEntityName}
-              getEntityTree={getEntityTree}
+              entityTrees={entityTrees}
               onTogglePackage={togglePackage}
               onToggleEntityType={toggleEntityType}
               onCreateStart={handleCreateEntityStart}

--- a/web_ui/features/editor/components/PackageFileTree.tsx
+++ b/web_ui/features/editor/components/PackageFileTree.tsx
@@ -499,19 +499,15 @@ export function PackageFileTree({
 
   // Fetch entity trees for all packages on mount
   useEffect(() => {
-    const loadEntityTrees = async () => {
-      for (const pkg of packages) {
-        await onPackageExpand(pkg.name);
-      }
+    Promise.all(packages.map((pkg) => onPackageExpand(pkg.name))).then(() => {
       // Auto-expand packages if none are expanded
       setExpandedPackages((prev) => {
         if (prev.size === 0) {
-          return new Set(packages.map(p => p.name));
+          return new Set(packages.map((p) => p.name));
         }
         return prev;
       });
-    };
-    loadEntityTrees();
+    });
   }, [packages, onPackageExpand]);
 
   const togglePackage = useCallback(


### PR DESCRIPTION
Used the `scanpackages` function instead of fetching it from the API in the editor page.

And when a package appeared expanded on initial load, the entity types showed up but were empty. This was because the component was calling a getter function that didn't subscribe to store updates. Even after the entity trees loaded asynchronously, the component didn't re-render to show the new data, it just wasn't "watching" the store for changes.

I used AI to help me update the file tree code. So let me know if it did a good job.