### PR TITLE
Truncate and wrap data table & detail panel

### DIFF
--- a/web_ui/components/data-table/DataTable.tsx
+++ b/web_ui/components/data-table/DataTable.tsx
@@ -448,7 +448,7 @@ export function DataTable<TData, TValue>({
                   }}
                 >
                   {row.getVisibleCells().map((cell) => (
-                    <td key={cell.id} className="px-4 py-3 text-sm dark:text-gray-300">
+                    <td key={cell.id} className="px-4 py-3 text-sm dark:text-gray-300 max-w-[200px] truncate">
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     </td>
                   ))}

--- a/web_ui/components/data-table/DataTable.tsx
+++ b/web_ui/components/data-table/DataTable.tsx
@@ -17,9 +17,13 @@ import {
 import { ChevronDown, Search, Filter, X } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
+import { cn } from '@/lib/utils';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { ColumnFilter } from './ColumnFilters';
 import type { Table, Column } from '@tanstack/react-table';
+
+const TRUNCATED_CELL_CLASS = 'max-w-[200px] truncate';
+const NON_TRUNCATED_COLUMN_IDS = new Set(['select', 'actions']);
 
 // Helper to get a human-readable column name from the header definition
 function getColumnDisplayName<TData>(column: Column<TData, unknown>): string {
@@ -36,6 +40,7 @@ export type DataTableColumnDef<TData, TValue = unknown> = ColumnDef<TData, TValu
   enableColumnFilter?: boolean;
   filterType?: 'text' | 'select' | 'multiselect';
   filterOptions?: string[];
+  truncate?: boolean;
 };
 
 // Component for the select all checkbox header
@@ -447,11 +452,22 @@ export function DataTable<TData, TValue>({
                     }
                   }}
                 >
-                  {row.getVisibleCells().map((cell) => (
-                    <td key={cell.id} className="px-4 py-3 text-sm dark:text-gray-300 max-w-[200px] truncate">
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </td>
-                  ))}
+                  {row.getVisibleCells().map((cell) => {
+                    const colDef = cell.column.columnDef as DataTableColumnDef<TData, TValue>;
+                    const shouldTruncate = colDef.truncate !== false && !NON_TRUNCATED_COLUMN_IDS.has(cell.column.id);
+                    const rawValue = shouldTruncate ? cell.getValue() : undefined;
+                    const titleText =
+                      typeof rawValue === 'string' || typeof rawValue === 'number' ? String(rawValue) : undefined;
+                    return (
+                      <td
+                        key={cell.id}
+                        title={titleText}
+                        className={cn('px-4 py-3 text-sm dark:text-gray-300', shouldTruncate && TRUNCATED_CELL_CLASS)}
+                      >
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </td>
+                    );
+                  })}
                 </tr>
               ))
             ) : (

--- a/web_ui/features/campaigns/components/CampaignsTable.tsx
+++ b/web_ui/features/campaigns/components/CampaignsTable.tsx
@@ -289,10 +289,12 @@ export function CampaignsTable({ initialData, protocolSpecs, taskSpecs }: Campai
       </div>
 
       {detailPanelOpen && selectedCampaign && (
-        <div className="w-96 border-l border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto self-start">
+        <div className="w-full max-w-[350px] border-l border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto self-start">
           <div className="flex items-start justify-between mb-6">
-            <div>
-              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{selectedCampaign.name}</h2>
+            <div className="max-w-full">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white break-words">
+                {selectedCampaign.name}
+              </h2>
               <p className="text-sm text-gray-500 dark:text-gray-400">Campaign Details</p>
             </div>
             <button

--- a/web_ui/features/campaigns/components/CampaignsTable.tsx
+++ b/web_ui/features/campaigns/components/CampaignsTable.tsx
@@ -8,7 +8,6 @@ import { DataTable, DataTableColumnDef } from '@/components/data-table/DataTable
 import { Button } from '@/components/ui/Button';
 import { RefreshControl } from '@/components/ui/RefreshControl';
 import { Badge, getStatusBadgeVariant } from '@/components/ui/Badge';
-import { JsonDisplay } from '@/components/ui/JsonDisplay';
 import { ErrorBox } from '@/components/ui/ErrorBox';
 import type { Campaign } from '@/lib/types/api';
 import type { PaginatedResult } from '@/lib/db/queries';
@@ -20,25 +19,10 @@ import { useServerTable } from '@/hooks/useServerTable';
 import { ConfirmDialog } from '@/components/dialogs/ConfirmDialog';
 import { SubmitCampaignDialog } from './SubmitCampaignDialog';
 import { useOrchestratorConnected } from '@/contexts/OrchestratorStatusContext';
-import { DetailField } from '@/features/protocol-runs/components/shared';
+import { ConditionalJsonSection, DetailField, TimelineSection } from '@/features/protocol-runs/components/shared';
+import { SECTION_DIVIDER } from '@/features/protocol-runs/styles';
 
-// Detail panel style constants
-const STYLES = {
-  label: 'text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide',
-  value: 'mt-1 text-sm text-gray-900 dark:text-gray-100',
-  textMuted: 'text-gray-500 dark:text-gray-400',
-  textNormal: 'text-gray-900 dark:text-gray-100',
-  section: 'border-t border-gray-200 dark:border-slate-700 pt-4',
-  sectionTitle: 'text-sm font-medium text-gray-900 dark:text-white',
-} as const;
-
-// Helper to check if data should be displayed
-const hasData = (data: unknown): boolean => {
-  if (!data) return false;
-  if (Array.isArray(data)) return data.length > 0;
-  if (typeof data === 'object') return Object.keys(data).length > 0;
-  return true;
-};
+const SECTION_TITLE = 'text-sm font-medium text-gray-900 dark:text-white';
 
 const CAMPAIGN_COLUMN_ID_MAP: Record<string, string> = {
   protocol: 'protocol',
@@ -243,7 +227,7 @@ export function CampaignsTable({ initialData, protocolSpecs, taskSpecs }: Campai
 
   return (
     <div className="flex gap-4">
-      <div className={`space-y-4 ${detailPanelOpen ? 'flex-1' : 'w-full'}`}>
+      <div className={`space-y-4 ${detailPanelOpen ? 'flex-1 min-w-0' : 'w-full'}`}>
         <div className="flex justify-between items-center">
           <div>
             <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Campaigns</h1>
@@ -289,23 +273,18 @@ export function CampaignsTable({ initialData, protocolSpecs, taskSpecs }: Campai
         />
       </div>
 
-            {detailPanelOpen && selectedCampaign && (
+      {detailPanelOpen && selectedCampaign && (
         <div className="w-96 border-l border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto self-start">
-
-          {/* Header */}
-          <div className="flex items-start justify-between mb-6">
+          <div className="flex items-start justify-between mb-6 gap-2">
             <div className="min-w-0">
               <h2 className="text-lg font-semibold text-gray-900 dark:text-white break-words">
                 {selectedCampaign.name}
               </h2>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                Campaign Details
-              </p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Campaign Details</p>
             </div>
-
             <button
               onClick={() => setDetailPanelOpen(false)}
-              className="rounded-sm opacity-70 ring-offset-white dark:ring-offset-slate-900 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 text-gray-900 dark:text-gray-400"
+              className="flex-shrink-0 rounded-sm opacity-70 ring-offset-white dark:ring-offset-slate-900 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 text-gray-900 dark:text-gray-400"
             >
               <X className="h-4 w-4" />
               <span className="sr-only">Close</span>
@@ -313,57 +292,39 @@ export function CampaignsTable({ initialData, protocolSpecs, taskSpecs }: Campai
           </div>
 
           <div className="space-y-6">
-
-            {/* Basic Info */}
             <div className="space-y-3">
               <DetailField label="Protocol" value={selectedCampaign.protocol} />
-
               <DetailField
                 label="Status"
                 value={
-                  <Badge variant={getStatusBadgeVariant(selectedCampaign.status)}>
-                    {selectedCampaign.status}
-                  </Badge>
+                  <Badge variant={getStatusBadgeVariant(selectedCampaign.status)}>{selectedCampaign.status}</Badge>
                 }
               />
-
               {selectedCampaign.status === 'FAILED' && selectedCampaign.error_message && (
                 <ErrorBox error={selectedCampaign.error_message} />
               )}
-
               <DetailField label="Owner" value={selectedCampaign.owner} />
-
               <DetailField label="Priority" value={selectedCampaign.priority} />
             </div>
 
-            {/* Progress */}
-            <div className={STYLES.section}>
-              <div className={`${STYLES.sectionTitle} mb-3`}>Progress</div>
-
+            <div className={SECTION_DIVIDER}>
+              <div className={`${SECTION_TITLE} mb-3`}>Progress</div>
               <div className="space-y-2">
+                <DetailField inline label="Completed" value={selectedCampaign.protocol_runs_completed} />
                 <DetailField
-                  label="Completed"
-                  value={selectedCampaign.protocol_runs_completed}
-                />
-
-                <DetailField
+                  inline
                   label="Max Protocol Runs"
                   value={selectedCampaign.max_protocol_runs === 0 ? '∞' : selectedCampaign.max_protocol_runs}
                 />
-
-                <DetailField
-                  label="Max Concurrent"
-                  value={selectedCampaign.max_concurrent_protocol_runs}
-                />
+                <DetailField inline label="Max Concurrent" value={selectedCampaign.max_concurrent_protocol_runs} />
               </div>
             </div>
 
-            {/* Optimization */}
-            <div className={STYLES.section}>
-              <div className={`${STYLES.sectionTitle} mb-3`}>Optimization</div>
-
+            <div className={SECTION_DIVIDER}>
+              <div className={`${SECTION_TITLE} mb-3`}>Optimization</div>
               <div className="space-y-2">
                 <DetailField
+                  inline
                   label="Enabled"
                   value={
                     <Badge variant={selectedCampaign.optimize ? 'info' : 'default'}>
@@ -371,70 +332,31 @@ export function CampaignsTable({ initialData, protocolSpecs, taskSpecs }: Campai
                     </Badge>
                   }
                 />
-
                 {selectedCampaign.optimize && (
                   <DetailField
+                    inline
                     label="Optimizer IP"
-                    value={
-                      <span className="font-mono text-xs break-all">
-                        {selectedCampaign.optimizer_ip}
-                      </span>
-                    }
+                    value={<span className="font-mono text-xs break-all">{selectedCampaign.optimizer_ip}</span>}
                   />
                 )}
               </div>
             </div>
 
-            {/* Timestamps */}
-            <div className={STYLES.section}>
-              <div className={STYLES.sectionTitle}>Timeline</div>
-
-              <div className="space-y-2">
-                <DetailField
-                  label="Created"
-                  value={new Date(selectedCampaign.created_at).toLocaleString()}
-                />
-
-                {selectedCampaign.start_time && (
-                  <DetailField
-                    label="Started"
-                    value={new Date(selectedCampaign.start_time).toLocaleString()}
-                  />
-                )}
-
-                {selectedCampaign.end_time && (
-                  <DetailField
-                    label="Ended"
-                    value={new Date(selectedCampaign.end_time).toLocaleString()}
-                  />
-                )}
-              </div>
+            <div className={SECTION_DIVIDER}>
+              <div className={`${SECTION_TITLE} mb-2`}>Timeline</div>
+              <TimelineSection
+                entries={[
+                  { label: 'Created', timestamp: selectedCampaign.created_at ?? null },
+                  { label: 'Started', timestamp: selectedCampaign.start_time ?? null },
+                  { label: 'Ended', timestamp: selectedCampaign.end_time ?? null },
+                ]}
+              />
             </div>
 
-            {/* JSON sections unchanged */}
-            {hasData(selectedCampaign.global_parameters) && (
-              <div className={STYLES.section}>
-                <JsonDisplay data={selectedCampaign.global_parameters} label="Global Parameters" />
-              </div>
-            )}
-
-            {hasData(selectedCampaign.protocol_run_parameters) && (
-              <div className={STYLES.section}>
-                <JsonDisplay data={selectedCampaign.protocol_run_parameters} label="Protocol Run Parameters" />
-              </div>
-            )}
-
-            {hasData(selectedCampaign.pareto_solutions) && (
-              <div className={STYLES.section}>
-                <JsonDisplay data={selectedCampaign.pareto_solutions} label="Pareto Solutions" />
-              </div>
-            )}
-
-            {hasData(selectedCampaign.meta) && (
-              <div className={STYLES.section}>
-                <JsonDisplay data={selectedCampaign.meta} label="Metadata" />
-              </div>
-            )}
+            <ConditionalJsonSection data={selectedCampaign.global_parameters} label="Global Parameters" />
+            <ConditionalJsonSection data={selectedCampaign.protocol_run_parameters} label="Protocol Run Parameters" />
+            <ConditionalJsonSection data={selectedCampaign.pareto_solutions} label="Pareto Solutions" />
+            <ConditionalJsonSection data={selectedCampaign.meta} label="Metadata" />
           </div>
         </div>
       )}

--- a/web_ui/features/campaigns/components/CampaignsTable.tsx
+++ b/web_ui/features/campaigns/components/CampaignsTable.tsx
@@ -20,6 +20,7 @@ import { useServerTable } from '@/hooks/useServerTable';
 import { ConfirmDialog } from '@/components/dialogs/ConfirmDialog';
 import { SubmitCampaignDialog } from './SubmitCampaignDialog';
 import { useOrchestratorConnected } from '@/contexts/OrchestratorStatusContext';
+import { DetailField } from '@/features/protocol-runs/components/shared';
 
 // Detail panel style constants
 const STYLES = {
@@ -288,15 +289,20 @@ export function CampaignsTable({ initialData, protocolSpecs, taskSpecs }: Campai
         />
       </div>
 
-      {detailPanelOpen && selectedCampaign && (
-        <div className="w-full max-w-[350px] border-l border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto self-start">
+            {detailPanelOpen && selectedCampaign && (
+        <div className="w-96 border-l border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto self-start">
+
+          {/* Header */}
           <div className="flex items-start justify-between mb-6">
-            <div className="max-w-full">
+            <div className="min-w-0">
               <h2 className="text-lg font-semibold text-gray-900 dark:text-white break-words">
                 {selectedCampaign.name}
               </h2>
-              <p className="text-sm text-gray-500 dark:text-gray-400">Campaign Details</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Campaign Details
+              </p>
             </div>
+
             <button
               onClick={() => setDetailPanelOpen(false)}
               className="rounded-sm opacity-70 ring-offset-white dark:ring-offset-slate-900 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 text-gray-900 dark:text-gray-400"
@@ -307,122 +313,123 @@ export function CampaignsTable({ initialData, protocolSpecs, taskSpecs }: Campai
           </div>
 
           <div className="space-y-6">
+
             {/* Basic Info */}
             <div className="space-y-3">
-              <div>
-                <div className={STYLES.label}>Protocol</div>
-                <div className={STYLES.value}>{selectedCampaign.protocol}</div>
-              </div>
+              <DetailField label="Protocol" value={selectedCampaign.protocol} />
 
-              <div>
-                <div className={STYLES.label}>Status</div>
-                <div className="mt-1">
-                  <Badge variant={getStatusBadgeVariant(selectedCampaign.status)}>{selectedCampaign.status}</Badge>
-                </div>
-              </div>
+              <DetailField
+                label="Status"
+                value={
+                  <Badge variant={getStatusBadgeVariant(selectedCampaign.status)}>
+                    {selectedCampaign.status}
+                  </Badge>
+                }
+              />
 
               {selectedCampaign.status === 'FAILED' && selectedCampaign.error_message && (
                 <ErrorBox error={selectedCampaign.error_message} />
               )}
 
-              <div>
-                <div className={STYLES.label}>Owner</div>
-                <div className={STYLES.value}>{selectedCampaign.owner}</div>
-              </div>
+              <DetailField label="Owner" value={selectedCampaign.owner} />
 
-              <div>
-                <div className={STYLES.label}>Priority</div>
-                <div className={STYLES.value}>{selectedCampaign.priority}</div>
-              </div>
+              <DetailField label="Priority" value={selectedCampaign.priority} />
             </div>
 
             {/* Progress */}
             <div className={STYLES.section}>
               <div className={`${STYLES.sectionTitle} mb-3`}>Progress</div>
-              <div className="space-y-2 text-sm">
-                <div className="flex justify-between">
-                  <span className={STYLES.textMuted}>Completed:</span>
-                  <span className={`${STYLES.textNormal} font-medium`}>{selectedCampaign.protocol_runs_completed}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className={STYLES.textMuted}>Max Protocol Runs:</span>
-                  <span className={`${STYLES.textNormal} font-medium`}>
-                    {selectedCampaign.max_protocol_runs === 0 ? '∞' : selectedCampaign.max_protocol_runs}
-                  </span>
-                </div>
-                <div className="flex justify-between">
-                  <span className={STYLES.textMuted}>Max Concurrent:</span>
-                  <span className={`${STYLES.textNormal} font-medium`}>
-                    {selectedCampaign.max_concurrent_protocol_runs}
-                  </span>
-                </div>
+
+              <div className="space-y-2">
+                <DetailField
+                  label="Completed"
+                  value={selectedCampaign.protocol_runs_completed}
+                />
+
+                <DetailField
+                  label="Max Protocol Runs"
+                  value={selectedCampaign.max_protocol_runs === 0 ? '∞' : selectedCampaign.max_protocol_runs}
+                />
+
+                <DetailField
+                  label="Max Concurrent"
+                  value={selectedCampaign.max_concurrent_protocol_runs}
+                />
               </div>
             </div>
 
             {/* Optimization */}
             <div className={STYLES.section}>
               <div className={`${STYLES.sectionTitle} mb-3`}>Optimization</div>
-              <div className="space-y-2 text-sm">
-                <div className="flex justify-between">
-                  <span className={STYLES.textMuted}>Enabled:</span>
-                  <Badge variant={selectedCampaign.optimize ? 'info' : 'default'}>
-                    {selectedCampaign.optimize ? 'Yes' : 'No'}
-                  </Badge>
-                </div>
+
+              <div className="space-y-2">
+                <DetailField
+                  label="Enabled"
+                  value={
+                    <Badge variant={selectedCampaign.optimize ? 'info' : 'default'}>
+                      {selectedCampaign.optimize ? 'Yes' : 'No'}
+                    </Badge>
+                  }
+                />
+
                 {selectedCampaign.optimize && (
-                  <div className="flex justify-between">
-                    <span className={STYLES.textMuted}>Optimizer IP:</span>
-                    <span className={`${STYLES.textNormal} font-mono text-xs`}>{selectedCampaign.optimizer_ip}</span>
-                  </div>
+                  <DetailField
+                    label="Optimizer IP"
+                    value={
+                      <span className="font-mono text-xs break-all">
+                        {selectedCampaign.optimizer_ip}
+                      </span>
+                    }
+                  />
                 )}
               </div>
             </div>
 
             {/* Timestamps */}
-            <div className={`${STYLES.section} space-y-2`}>
+            <div className={STYLES.section}>
               <div className={STYLES.sectionTitle}>Timeline</div>
-              <div className="space-y-1 text-xs">
-                <div>
-                  <span className={STYLES.textMuted}>Created:</span>{' '}
-                  <span className={STYLES.textNormal}>{new Date(selectedCampaign.created_at).toLocaleString()}</span>
-                </div>
+
+              <div className="space-y-2">
+                <DetailField
+                  label="Created"
+                  value={new Date(selectedCampaign.created_at).toLocaleString()}
+                />
+
                 {selectedCampaign.start_time && (
-                  <div>
-                    <span className={STYLES.textMuted}>Started:</span>{' '}
-                    <span className={STYLES.textNormal}>{new Date(selectedCampaign.start_time).toLocaleString()}</span>
-                  </div>
+                  <DetailField
+                    label="Started"
+                    value={new Date(selectedCampaign.start_time).toLocaleString()}
+                  />
                 )}
+
                 {selectedCampaign.end_time && (
-                  <div>
-                    <span className={STYLES.textMuted}>Ended:</span>{' '}
-                    <span className={STYLES.textNormal}>{new Date(selectedCampaign.end_time).toLocaleString()}</span>
-                  </div>
+                  <DetailField
+                    label="Ended"
+                    value={new Date(selectedCampaign.end_time).toLocaleString()}
+                  />
                 )}
               </div>
             </div>
 
-            {/* Global Parameters */}
+            {/* JSON sections unchanged */}
             {hasData(selectedCampaign.global_parameters) && (
               <div className={STYLES.section}>
                 <JsonDisplay data={selectedCampaign.global_parameters} label="Global Parameters" />
               </div>
             )}
 
-            {/* Protocol Run Parameters */}
             {hasData(selectedCampaign.protocol_run_parameters) && (
               <div className={STYLES.section}>
                 <JsonDisplay data={selectedCampaign.protocol_run_parameters} label="Protocol Run Parameters" />
               </div>
             )}
 
-            {/* Pareto Solutions */}
             {hasData(selectedCampaign.pareto_solutions) && (
               <div className={STYLES.section}>
                 <JsonDisplay data={selectedCampaign.pareto_solutions} label="Pareto Solutions" />
               </div>
             )}
 
-            {/* Metadata */}
             {hasData(selectedCampaign.meta) && (
               <div className={STYLES.section}>
                 <JsonDisplay data={selectedCampaign.meta} label="Metadata" />

--- a/web_ui/features/protocol-runs/components/ProtocolRunsTable.tsx
+++ b/web_ui/features/protocol-runs/components/ProtocolRunsTable.tsx
@@ -230,7 +230,7 @@ export function ProtocolRunsTable({ initialData, protocolSpecs, taskSpecs, labSp
 
   return (
     <div className="flex gap-4">
-      <div className={`space-y-4 ${detailPanelOpen ? 'flex-1' : 'w-full'}`}>
+      <div className={`space-y-4 ${detailPanelOpen ? 'flex-1 min-w-0' : 'w-full'}`}>
         <div className="flex justify-between items-center">
           <div>
             <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Protocol Runs</h1>
@@ -278,20 +278,17 @@ export function ProtocolRunsTable({ initialData, protocolSpecs, taskSpecs, labSp
       </div>
 
       {detailPanelOpen && selectedProtocolRun && (
-        <div className="w-96 min-w-0 border-l border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto overflow-x-hidden self-start">
-
-          <div className="flex items-start justify-between mb-6 min-w-0">
+        <div className="w-96 border-l border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto self-start">
+          <div className="flex items-start justify-between mb-6 gap-2">
             <div className="min-w-0">
               <h2 className="text-lg font-semibold text-gray-900 dark:text-white break-words">
                 {selectedProtocolRun.name}
               </h2>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                Protocol Run Details
-              </p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Protocol Run Details</p>
             </div>
             <button
               onClick={() => setDetailPanelOpen(false)}
-              className="rounded-sm opacity-70 ring-offset-white dark:ring-offset-slate-900 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 text-gray-900 dark:text-gray-400"
+              className="flex-shrink-0 rounded-sm opacity-70 ring-offset-white dark:ring-offset-slate-900 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 text-gray-900 dark:text-gray-400"
             >
               <X className="h-4 w-4" />
               <span className="sr-only">Close</span>

--- a/web_ui/features/protocol-runs/components/ProtocolRunsTable.tsx
+++ b/web_ui/features/protocol-runs/components/ProtocolRunsTable.tsx
@@ -278,11 +278,16 @@ export function ProtocolRunsTable({ initialData, protocolSpecs, taskSpecs, labSp
       </div>
 
       {detailPanelOpen && selectedProtocolRun && (
-        <div className="w-96 border-l border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto self-start">
-          <div className="flex items-start justify-between mb-6">
-            <div>
-              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{selectedProtocolRun.name}</h2>
-              <p className="text-sm text-gray-500 dark:text-gray-400">Protocol Run Details</p>
+        <div className="w-96 min-w-0 border-l border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto overflow-x-hidden self-start">
+
+          <div className="flex items-start justify-between mb-6 min-w-0">
+            <div className="min-w-0">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white break-words">
+                {selectedProtocolRun.name}
+              </h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Protocol Run Details
+              </p>
             </div>
             <button
               onClick={() => setDetailPanelOpen(false)}

--- a/web_ui/features/protocol-runs/components/shared/DetailField.tsx
+++ b/web_ui/features/protocol-runs/components/shared/DetailField.tsx
@@ -1,22 +1,27 @@
-import { DETAIL_LABEL, DETAIL_VALUE } from '../../styles';
 import { cn } from '@/lib/utils';
+import { DETAIL_LABEL, DETAIL_VALUE } from '../../styles';
 
 interface DetailFieldProps {
   label: string;
   value: React.ReactNode;
   className?: string;
+  inline?: boolean;
 }
 
-export function DetailField({ label, value, className }: DetailFieldProps) {
-  return (
-    <div className={cn("text-xs text-gray-500 dark:text-gray-400 mb-1", className)}>
-      <div className={cn(DETAIL_LABEL, "flex-shrink-0")}>
-        {label}
+export function DetailField({ label, value, className, inline }: DetailFieldProps) {
+  if (inline) {
+    return (
+      <div className={cn('flex items-center justify-between gap-2 text-sm', className)}>
+        <span className="text-gray-500 dark:text-gray-400 flex-shrink-0">{label}:</span>
+        <span className="text-gray-900 dark:text-gray-100 font-medium text-right break-words min-w-0">{value}</span>
       </div>
+    );
+  }
 
-      <div className={cn(DETAIL_VALUE, "text-sm text-gray-900 dark:text-white break-words")}>
-        {value}
-      </div>
+  return (
+    <div className={className}>
+      <div className={DETAIL_LABEL}>{label}</div>
+      <div className={cn(DETAIL_VALUE, 'break-words')}>{value}</div>
     </div>
   );
 }

--- a/web_ui/features/protocol-runs/components/shared/DetailField.tsx
+++ b/web_ui/features/protocol-runs/components/shared/DetailField.tsx
@@ -1,4 +1,5 @@
 import { DETAIL_LABEL, DETAIL_VALUE } from '../../styles';
+import { cn } from '@/lib/utils';
 
 interface DetailFieldProps {
   label: string;
@@ -8,9 +9,14 @@ interface DetailFieldProps {
 
 export function DetailField({ label, value, className }: DetailFieldProps) {
   return (
-    <div className={className}>
-      <div className={DETAIL_LABEL}>{label}</div>
-      <div className={DETAIL_VALUE}>{value}</div>
+    <div className={cn("text-xs text-gray-500 dark:text-gray-400 mb-1", className)}>
+      <div className={cn(DETAIL_LABEL, "flex-shrink-0")}>
+        {label}
+      </div>
+
+      <div className={cn(DETAIL_VALUE, "text-sm text-gray-900 dark:text-white break-words")}>
+        {value}
+      </div>
     </div>
   );
 }

--- a/web_ui/features/tasks/components/TasksTable.tsx
+++ b/web_ui/features/tasks/components/TasksTable.tsx
@@ -20,6 +20,7 @@ import { TaskOutputFiles } from '@/features/files/components/TaskOutputFiles';
 import type { TaskSpec } from '@/lib/types/protocol';
 import type { LabSpec } from '@/lib/api/specs';
 import { useOrchestratorConnected } from '@/contexts/OrchestratorStatusContext';
+import { DetailField } from '@/features/protocol-runs/components/shared';
 
 const TASK_COLUMN_ID_MAP: Record<string, string> = {
   protocol_run_name: 'protocolRunName',
@@ -246,15 +247,22 @@ export function TasksTable({ initialData, taskSpecs, labSpecs }: TasksTableProps
       </div>
 
       {detailPanelOpen && selectedTask && (
-        <div className="w-96 border-l border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto self-start">
-          <div className="flex items-start justify-between mb-6">
-            <div>
-              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{selectedTask.name}</h2>
-              <p className="text-sm text-gray-500 dark:text-gray-400">Task Details</p>
+        <div className="w-96 min-w-0 border-l border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto overflow-x-hidden self-start">
+
+          {/* Header */}
+          <div className="flex items-start justify-between mb-6 min-w-0">
+            <div className="min-w-0">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white break-words">
+                {selectedTask.name}
+              </h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Task Details
+              </p>
             </div>
+
             <button
               onClick={() => setDetailPanelOpen(false)}
-              className="rounded-sm opacity-70 ring-offset-white dark:ring-offset-slate-900 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 text-gray-900 dark:text-gray-400"
+              className="rounded-sm opacity-70 ring-offset-white dark:ring-offset-slate-900 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 text-gray-900 dark:text-gray-400 flex-shrink-0"
             >
               <X className="h-4 w-4" />
               <span className="sr-only">Close</span>
@@ -262,115 +270,102 @@ export function TasksTable({ initialData, taskSpecs, labSpecs }: TasksTableProps
           </div>
 
           <div className="space-y-6">
+
             {/* Basic Info */}
             <div className="space-y-3">
-              <div>
-                <div className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">Type</div>
-                <div className="mt-1 text-sm text-gray-900 dark:text-gray-100">{selectedTask.type}</div>
-              </div>
 
-              <div>
-                <div className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-                  Status
-                </div>
-                <div className="mt-1">
-                  <Badge variant={getStatusBadgeVariant(selectedTask.status)}>{selectedTask.status}</Badge>
-                </div>
-              </div>
+              <DetailField label="Type" value={selectedTask.type} />
+
+              <DetailField
+                label="Status"
+                value={
+                  <Badge variant={getStatusBadgeVariant(selectedTask.status)}>
+                    {selectedTask.status}
+                  </Badge>
+                }
+              />
 
               {selectedTask.status === 'FAILED' && selectedTask.error_message && (
                 <ErrorBox error={selectedTask.error_message} />
               )}
 
               {selectedTask.protocol_run_name && (
-                <div>
-                  <div className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-                    Protocol Run
-                  </div>
-                  <div className="mt-1 text-sm text-gray-900 dark:text-gray-100">{selectedTask.protocol_run_name}</div>
-                </div>
+                <DetailField
+                  label="Protocol Run"
+                  value={
+                    <span className="break-all">
+                      {selectedTask.protocol_run_name}
+                    </span>
+                  }
+                />
               )}
 
-              <div>
-                <div className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-                  Priority
-                </div>
-                <div className="mt-1 text-sm text-gray-900 dark:text-gray-100">{selectedTask.priority}</div>
-              </div>
+              <DetailField label="Priority" value={selectedTask.priority} />
 
-              <div>
-                <div className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-                  Allocation Timeout
-                </div>
-                <div className="mt-1 text-sm text-gray-900 dark:text-gray-100">{selectedTask.allocation_timeout}s</div>
-              </div>
+              <DetailField
+                label="Allocation Timeout"
+                value={`${selectedTask.allocation_timeout}s`}
+              />
             </div>
 
-            {/* Timestamps */}
+            {/* Timeline */}
             <div className="border-t border-gray-200 dark:border-slate-700 pt-4 space-y-2">
-              <div className="text-sm font-medium text-gray-900 dark:text-white">Timeline</div>
-              <div className="space-y-1 text-xs">
-                <div>
-                  <span className="text-gray-500 dark:text-gray-400">Created:</span>{' '}
-                  <span className="text-gray-900 dark:text-gray-100">
-                    {new Date(selectedTask.created_at).toLocaleString()}
-                  </span>
-                </div>
-                {selectedTask.start_time && (
-                  <div>
-                    <span className="text-gray-500 dark:text-gray-400">Started:</span>{' '}
-                    <span className="text-gray-900 dark:text-gray-100">
-                      {new Date(selectedTask.start_time).toLocaleString()}
-                    </span>
-                  </div>
-                )}
-                {selectedTask.end_time && (
-                  <div>
-                    <span className="text-gray-500 dark:text-gray-400">Ended:</span>{' '}
-                    <span className="text-gray-900 dark:text-gray-100">
-                      {new Date(selectedTask.end_time).toLocaleString()}
-                    </span>
-                  </div>
-                )}
+
+              <div className="text-sm font-medium text-gray-900 dark:text-white">
+                Timeline
               </div>
+
+              <DetailField
+                label="Created"
+                value={new Date(selectedTask.created_at).toLocaleString()}
+              />
+
+              {selectedTask.start_time && (
+                <DetailField
+                  label="Started"
+                  value={new Date(selectedTask.start_time).toLocaleString()}
+                />
+              )}
+
+              {selectedTask.end_time && (
+                <DetailField
+                  label="Ended"
+                  value={new Date(selectedTask.end_time).toLocaleString()}
+                />
+              )}
             </div>
 
-            {/* Devices */}
+            {/* JSON sections */}
             {selectedTask.devices && Object.keys(selectedTask.devices).length > 0 && (
               <div className="border-t border-gray-200 dark:border-slate-700 pt-4">
                 <JsonDisplay data={selectedTask.devices} label="Devices" />
               </div>
             )}
 
-            {/* Input Parameters */}
             {selectedTask.input_parameters && (
               <div className="border-t border-gray-200 dark:border-slate-700 pt-4">
                 <JsonDisplay data={selectedTask.input_parameters} label="Input Parameters" />
               </div>
             )}
 
-            {/* Input Resources */}
             {selectedTask.input_resources && (
               <div className="border-t border-gray-200 dark:border-slate-700 pt-4">
                 <JsonDisplay data={selectedTask.input_resources} label="Input Resources" />
               </div>
             )}
 
-            {/* Output Parameters */}
             {selectedTask.output_parameters && (
               <div className="border-t border-gray-200 dark:border-slate-700 pt-4">
                 <JsonDisplay data={selectedTask.output_parameters} label="Output Parameters" />
               </div>
             )}
 
-            {/* Output Resources */}
             {selectedTask.output_resources && (
               <div className="border-t border-gray-200 dark:border-slate-700 pt-4">
                 <JsonDisplay data={selectedTask.output_resources} label="Output Resources" />
               </div>
             )}
 
-            {/* Output Files */}
             {selectedTask.output_file_names && selectedTask.output_file_names.length > 0 && (
               <div className="border-t border-gray-200 dark:border-slate-700 pt-4">
                 <TaskOutputFiles
@@ -381,12 +376,12 @@ export function TasksTable({ initialData, taskSpecs, labSpecs }: TasksTableProps
               </div>
             )}
 
-            {/* Metadata */}
             {selectedTask.meta && Object.keys(selectedTask.meta).length > 0 && (
               <div className="border-t border-gray-200 dark:border-slate-700 pt-4">
                 <JsonDisplay data={selectedTask.meta} label="Metadata" />
               </div>
             )}
+
           </div>
         </div>
       )}

--- a/web_ui/features/tasks/components/TasksTable.tsx
+++ b/web_ui/features/tasks/components/TasksTable.tsx
@@ -7,7 +7,6 @@ import { DataTable, DataTableColumnDef } from '@/components/data-table/DataTable
 import { Button } from '@/components/ui/Button';
 import { RefreshControl } from '@/components/ui/RefreshControl';
 import { Badge, getStatusBadgeVariant } from '@/components/ui/Badge';
-import { JsonDisplay } from '@/components/ui/JsonDisplay';
 import type { Task } from '@/lib/types/api';
 import type { PaginatedResult } from '@/lib/db/queries';
 import { cancelTask, getTasks } from '@/features/tasks/api/tasks';
@@ -20,7 +19,8 @@ import { TaskOutputFiles } from '@/features/files/components/TaskOutputFiles';
 import type { TaskSpec } from '@/lib/types/protocol';
 import type { LabSpec } from '@/lib/api/specs';
 import { useOrchestratorConnected } from '@/contexts/OrchestratorStatusContext';
-import { DetailField } from '@/features/protocol-runs/components/shared';
+import { ConditionalJsonSection, DetailField, TimelineSection } from '@/features/protocol-runs/components/shared';
+import { SECTION_DIVIDER } from '@/features/protocol-runs/styles';
 
 const TASK_COLUMN_ID_MAP: Record<string, string> = {
   protocol_run_name: 'protocolRunName',
@@ -200,7 +200,7 @@ export function TasksTable({ initialData, taskSpecs, labSpecs }: TasksTableProps
 
   return (
     <div className="flex gap-4">
-      <div className={`space-y-4 ${detailPanelOpen ? 'flex-1' : 'w-full'}`}>
+      <div className={`space-y-4 ${detailPanelOpen ? 'flex-1 min-w-0' : 'w-full'}`}>
         <div className="flex justify-between items-center">
           <div>
             <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Tasks</h1>
@@ -247,22 +247,15 @@ export function TasksTable({ initialData, taskSpecs, labSpecs }: TasksTableProps
       </div>
 
       {detailPanelOpen && selectedTask && (
-        <div className="w-96 min-w-0 border-l border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto overflow-x-hidden self-start">
-
-          {/* Header */}
-          <div className="flex items-start justify-between mb-6 min-w-0">
+        <div className="w-96 border-l border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto self-start">
+          <div className="flex items-start justify-between mb-6 gap-2">
             <div className="min-w-0">
-              <h2 className="text-lg font-semibold text-gray-900 dark:text-white break-words">
-                {selectedTask.name}
-              </h2>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                Task Details
-              </p>
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white break-words">{selectedTask.name}</h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Task Details</p>
             </div>
-
             <button
               onClick={() => setDetailPanelOpen(false)}
-              className="rounded-sm opacity-70 ring-offset-white dark:ring-offset-slate-900 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 text-gray-900 dark:text-gray-400 flex-shrink-0"
+              className="flex-shrink-0 rounded-sm opacity-70 ring-offset-white dark:ring-offset-slate-900 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 text-gray-900 dark:text-gray-400"
             >
               <X className="h-4 w-4" />
               <span className="sr-only">Close</span>
@@ -270,104 +263,41 @@ export function TasksTable({ initialData, taskSpecs, labSpecs }: TasksTableProps
           </div>
 
           <div className="space-y-6">
-
-            {/* Basic Info */}
             <div className="space-y-3">
-
               <DetailField label="Type" value={selectedTask.type} />
-
               <DetailField
                 label="Status"
-                value={
-                  <Badge variant={getStatusBadgeVariant(selectedTask.status)}>
-                    {selectedTask.status}
-                  </Badge>
-                }
+                value={<Badge variant={getStatusBadgeVariant(selectedTask.status)}>{selectedTask.status}</Badge>}
               />
-
               {selectedTask.status === 'FAILED' && selectedTask.error_message && (
                 <ErrorBox error={selectedTask.error_message} />
               )}
-
               {selectedTask.protocol_run_name && (
-                <DetailField
-                  label="Protocol Run"
-                  value={
-                    <span className="break-all">
-                      {selectedTask.protocol_run_name}
-                    </span>
-                  }
-                />
+                <DetailField label="Protocol Run" value={selectedTask.protocol_run_name} />
               )}
-
               <DetailField label="Priority" value={selectedTask.priority} />
+              <DetailField label="Allocation Timeout" value={`${selectedTask.allocation_timeout}s`} />
+            </div>
 
-              <DetailField
-                label="Allocation Timeout"
-                value={`${selectedTask.allocation_timeout}s`}
+            <div className={SECTION_DIVIDER}>
+              <div className="text-sm font-medium text-gray-900 dark:text-white mb-2">Timeline</div>
+              <TimelineSection
+                entries={[
+                  { label: 'Created', timestamp: selectedTask.created_at ?? null },
+                  { label: 'Started', timestamp: selectedTask.start_time ?? null },
+                  { label: 'Ended', timestamp: selectedTask.end_time ?? null },
+                ]}
               />
             </div>
 
-            {/* Timeline */}
-            <div className="border-t border-gray-200 dark:border-slate-700 pt-4 space-y-2">
-
-              <div className="text-sm font-medium text-gray-900 dark:text-white">
-                Timeline
-              </div>
-
-              <DetailField
-                label="Created"
-                value={new Date(selectedTask.created_at).toLocaleString()}
-              />
-
-              {selectedTask.start_time && (
-                <DetailField
-                  label="Started"
-                  value={new Date(selectedTask.start_time).toLocaleString()}
-                />
-              )}
-
-              {selectedTask.end_time && (
-                <DetailField
-                  label="Ended"
-                  value={new Date(selectedTask.end_time).toLocaleString()}
-                />
-              )}
-            </div>
-
-            {/* JSON sections */}
-            {selectedTask.devices && Object.keys(selectedTask.devices).length > 0 && (
-              <div className="border-t border-gray-200 dark:border-slate-700 pt-4">
-                <JsonDisplay data={selectedTask.devices} label="Devices" />
-              </div>
-            )}
-
-            {selectedTask.input_parameters && (
-              <div className="border-t border-gray-200 dark:border-slate-700 pt-4">
-                <JsonDisplay data={selectedTask.input_parameters} label="Input Parameters" />
-              </div>
-            )}
-
-            {selectedTask.input_resources && (
-              <div className="border-t border-gray-200 dark:border-slate-700 pt-4">
-                <JsonDisplay data={selectedTask.input_resources} label="Input Resources" />
-              </div>
-            )}
-
-            {selectedTask.output_parameters && (
-              <div className="border-t border-gray-200 dark:border-slate-700 pt-4">
-                <JsonDisplay data={selectedTask.output_parameters} label="Output Parameters" />
-              </div>
-            )}
-
-            {selectedTask.output_resources && (
-              <div className="border-t border-gray-200 dark:border-slate-700 pt-4">
-                <JsonDisplay data={selectedTask.output_resources} label="Output Resources" />
-              </div>
-            )}
+            <ConditionalJsonSection data={selectedTask.devices} label="Devices" />
+            <ConditionalJsonSection data={selectedTask.input_parameters} label="Input Parameters" />
+            <ConditionalJsonSection data={selectedTask.input_resources} label="Input Resources" />
+            <ConditionalJsonSection data={selectedTask.output_parameters} label="Output Parameters" />
+            <ConditionalJsonSection data={selectedTask.output_resources} label="Output Resources" />
 
             {selectedTask.output_file_names && selectedTask.output_file_names.length > 0 && (
-              <div className="border-t border-gray-200 dark:border-slate-700 pt-4">
+              <div className={SECTION_DIVIDER}>
                 <TaskOutputFiles
                   fileNames={selectedTask.output_file_names}
                   protocolRunName={selectedTask.protocol_run_name ?? null}
@@ -376,12 +306,7 @@ export function TasksTable({ initialData, taskSpecs, labSpecs }: TasksTableProps
               </div>
             )}
 
-            {selectedTask.meta && Object.keys(selectedTask.meta).length > 0 && (
-              <div className="border-t border-gray-200 dark:border-slate-700 pt-4">
-                <JsonDisplay data={selectedTask.meta} label="Metadata" />
-              </div>
-            )}
-
+            <ConditionalJsonSection data={selectedTask.meta} label="Metadata" />
           </div>
         </div>
       )}


### PR DESCRIPTION
When campaigns, protocols, or tasks have very long names, they break the layout of the data table and leave insufficient space for the details panel.

<img width="1521" height="901" alt="broken-table-and-panel" src="https://github.com/user-attachments/assets/7bcdeb44-429e-4272-88a2-8558d8eacfba" />

---

This issue was fixed by truncating values in the cells of the `DataTable` component and ensuring proper flex and overflow handling to prevent horizontal layout breakage.

Additionally, the `DetailField` component was updated to properly support text wrapping for long values (including unbroken strings such as IDs and slugs).

Finally, the campaign, protocol, and task detail views were refactored to consistently use the `DetailField` component, improving both styling consistency and resilience against long content.

<img width="1508" height="531" alt="fixed-table-and-panel" src="https://github.com/user-attachments/assets/5851bd2f-bd63-4625-a390-f468c0151d1f" />
