### PR TITLE
Exluded funcs in sila device mixing class

### DIFF
--- a/eos/devices/base_device.py
+++ b/eos/devices/base_device.py
@@ -1,5 +1,6 @@
 import asyncio
 import atexit
+import functools
 import inspect
 from abc import ABC, abstractmethod
 from enum import Enum
@@ -9,7 +10,6 @@ from eos.devices.exceptions import (
     EosDeviceInitializationError,
     EosDeviceCleanupError,
 )
-from eos.integrations.sila.sila_device_mixin import SilaDeviceMixin
 
 
 def register_async_exit_callback(async_fn, *args, **kwargs) -> None:
@@ -160,90 +160,7 @@ class BaseDevice(ABC):
         Get information about all public methods (functions) available on this device.
         Returns a dictionary with function names as keys and metadata as values.
         """
-        functions = {}
-
-        sila_defined = {
-            name
-            for name, val in SilaDeviceMixin.__dict__.items()
-            if (
-                inspect.isfunction(val)
-                or isinstance(val, (staticmethod, classmethod))
-            )
-            and not name.startswith("_")
-        }
-
-        # Get all members of the class
-        for name, method in inspect.getmembers(self, predicate=inspect.ismethod):
-            # Skip private methods (starting with _) and inherited base methods
-            if name.startswith("_"):
-                continue
-
-            # Skip BaseDevice methods that are not device-specific
-            if name in [
-                "initialize",
-                "cleanup",
-                "report",
-                "enable",
-                "disable",
-                "get_status",
-                "get_name",
-                "get_lab_name",
-                "get_device_type",
-                "get_init_parameters",
-                "get_available_functions",
-            ]:
-                continue
-
-            if name in sila_defined:
-                continue
-
-            try:
-                sig = inspect.signature(method)
-                params = []
-
-                for param_name, param in sig.parameters.items():
-                    # Skip 'self' parameter and internal Ray parameters
-                    if param_name == "self" or param_name.startswith("_ray_"):
-                        continue
-
-                    # Format type annotation nicely
-                    type_str = "Any"
-                    if param.annotation != inspect.Parameter.empty:
-                        type_obj = param.annotation
-                        if hasattr(type_obj, "__name__"):
-                            type_str = type_obj.__name__
-                        else:
-                            type_str = str(type_obj).replace("typing.", "")
-
-                    param_info = {
-                        "name": param_name,
-                        "type": type_str,
-                        "required": param.default == inspect.Parameter.empty,
-                        "default": str(param.default) if param.default != inspect.Parameter.empty else None,
-                    }
-                    params.append(param_info)
-
-                # Format return type annotation nicely
-                return_type_str = "Any"
-                if sig.return_annotation != inspect.Signature.empty:
-                    return_obj = sig.return_annotation
-                    if hasattr(return_obj, "__name__"):
-                        return_type_str = return_obj.__name__
-                    else:
-                        return_type_str = str(return_obj).replace("typing.", "")
-
-                functions[name] = {
-                    "name": name,
-                    "parameters": params,
-                    "return_type": return_type_str,
-                    "docstring": inspect.getdoc(method) or "",
-                    "is_async": inspect.iscoroutinefunction(method),
-                }
-            except Exception:  # noqa: S112
-                # If we can't inspect the method for any reason, skip it
-                continue
-
-        return functions
+        return _build_available_functions(type(self))
 
     @abstractmethod
     async def _initialize(self, initialization_parameters: dict[str, Any]) -> None:
@@ -262,3 +179,57 @@ class BaseDevice(ABC):
         """
         Implementation for the report method.
         """
+
+
+@functools.cache
+def _build_available_functions(cls: type) -> dict[str, Any]:
+    """Return metadata for public methods defined on BaseDevice subclasses of cls."""
+    exposed_names = {
+        name
+        for klass in cls.__mro__
+        if issubclass(klass, BaseDevice) and klass is not BaseDevice
+        for name, val in klass.__dict__.items()
+        if not name.startswith("_") and (inspect.isfunction(val) or isinstance(val, (staticmethod, classmethod)))
+    }
+
+    functions = {}
+    for name in exposed_names:
+        method = getattr(cls, name, None)
+        if method is None:
+            continue
+        try:
+            sig = inspect.signature(method)
+        except (ValueError, TypeError):
+            continue
+
+        params = []
+        for param_name, param in sig.parameters.items():
+            # Skip 'self' parameter and internal Ray parameters
+            if param_name == "self" or param_name.startswith("_ray_"):
+                continue
+            params.append(
+                {
+                    "name": param_name,
+                    "type": _format_annotation(param.annotation, inspect.Parameter.empty),
+                    "required": param.default == inspect.Parameter.empty,
+                    "default": str(param.default) if param.default != inspect.Parameter.empty else None,
+                }
+            )
+
+        functions[name] = {
+            "name": name,
+            "parameters": params,
+            "return_type": _format_annotation(sig.return_annotation, inspect.Signature.empty),
+            "docstring": inspect.getdoc(method) or "",
+            "is_async": inspect.iscoroutinefunction(method),
+        }
+
+    return functions
+
+
+def _format_annotation(annotation: Any, empty_sentinel: Any) -> str:
+    if annotation is empty_sentinel:
+        return "Any"
+    if hasattr(annotation, "__name__"):
+        return annotation.__name__
+    return str(annotation).replace("typing.", "")

--- a/eos/devices/base_device.py
+++ b/eos/devices/base_device.py
@@ -9,6 +9,7 @@ from eos.devices.exceptions import (
     EosDeviceInitializationError,
     EosDeviceCleanupError,
 )
+from eos.integrations.sila.sila_device_mixin import SilaDeviceMixin
 
 
 def register_async_exit_callback(async_fn, *args, **kwargs) -> None:
@@ -161,6 +162,16 @@ class BaseDevice(ABC):
         """
         functions = {}
 
+        sila_defined = {
+            name
+            for name, val in SilaDeviceMixin.__dict__.items()
+            if (
+                inspect.isfunction(val)
+                or isinstance(val, (staticmethod, classmethod))
+            )
+            and not name.startswith("_")
+        }
+
         # Get all members of the class
         for name, method in inspect.getmembers(self, predicate=inspect.ismethod):
             # Skip private methods (starting with _) and inherited base methods
@@ -181,6 +192,9 @@ class BaseDevice(ABC):
                 "get_init_parameters",
                 "get_available_functions",
             ]:
+                continue
+
+            if name in sila_defined:
                 continue
 
             try:

--- a/tests/devices/test_base_device.py
+++ b/tests/devices/test_base_device.py
@@ -99,3 +99,108 @@ class TestBaseDevice:
         with pytest.raises(EosDeviceInitializationError):
             await mock_device.initialize({})
         assert mock_device.status == DeviceStatus.IDLE
+
+
+class _MixinForTest:
+    """Stand-in for an integration mixin (e.g. SilaDeviceMixin); not a BaseDevice subclass."""
+
+    def mixin_public_method(self, value: int = 0) -> int:
+        return value
+
+    def _mixin_private(self) -> None:
+        pass
+
+
+class _DeviceBaseForTest(BaseDevice):
+    """Intermediate device base class. Its public methods should still be exposed."""
+
+    async def _initialize(self, init_parameters: dict[str, Any]) -> None:
+        pass
+
+    async def _cleanup(self) -> None:
+        pass
+
+    async def _report(self) -> dict[str, Any]:
+        return {}
+
+    def base_public_method(self) -> str:
+        return "base"
+
+
+class _UserDevice(_DeviceBaseForTest, _MixinForTest):
+    """Concrete user device combining a BaseDevice subclass with a non-BaseDevice mixin."""
+
+    def user_public_method(self, name: str, count: int = 1) -> bool:
+        """User-defined method docstring."""
+        return True
+
+    async def user_async_method(self) -> None:
+        pass
+
+    def _user_private(self) -> None:
+        pass
+
+
+class TestGetAvailableFunctions:
+    @pytest.fixture
+    def device(self):
+        return _UserDevice("test", "lab", "user")
+
+    def test_includes_user_methods(self, device):
+        functions = device.get_available_functions()
+        assert "user_public_method" in functions
+        assert "user_async_method" in functions
+
+    def test_includes_intermediate_base_methods(self, device):
+        functions = device.get_available_functions()
+        assert "base_public_method" in functions
+
+    def test_excludes_private_methods(self, device):
+        functions = device.get_available_functions()
+        for name in ["_user_private", "_mixin_private", "_initialize", "_cleanup", "_report"]:
+            assert name not in functions
+
+    def test_excludes_basedevice_methods(self, device):
+        functions = device.get_available_functions()
+        for name in [
+            "initialize",
+            "cleanup",
+            "report",
+            "enable",
+            "disable",
+            "get_status",
+            "get_name",
+            "get_lab_name",
+            "get_device_type",
+            "get_init_parameters",
+            "get_available_functions",
+        ]:
+            assert name not in functions
+
+    def test_excludes_non_basedevice_mixin_methods(self, device):
+        # The whole point: a mixin that isn't a BaseDevice subclass is hidden,
+        # without BaseDevice having to know about it.
+        assert "mixin_public_method" not in device.get_available_functions()
+
+    def test_metadata_shape(self, device):
+        meta = device.get_available_functions()["user_public_method"]
+        assert meta["name"] == "user_public_method"
+        assert meta["return_type"] == "bool"
+        assert meta["is_async"] is False
+        assert meta["docstring"] == "User-defined method docstring."
+
+        params = {p["name"]: p for p in meta["parameters"]}
+        assert "self" not in params
+        assert params["name"]["type"] == "str"
+        assert params["name"]["required"] is True
+        assert params["count"]["type"] == "int"
+        assert params["count"]["required"] is False
+        assert params["count"]["default"] == "1"
+
+    def test_async_method_flagged(self, device):
+        assert device.get_available_functions()["user_async_method"]["is_async"] is True
+
+    def test_result_is_cached_per_class(self, device):
+        a = device.get_available_functions()
+        b = _UserDevice("other", "lab", "user").get_available_functions()
+        assert a is b


### PR DESCRIPTION
In the device inspector exclude the function defined by the `SilaDeviceMixin` class as they clutter up the available functions section.