### PR TITLE
Limit host port of web-ui docker container to localhost

### DIFF
--- a/web_ui/docker-compose.yml
+++ b/web_ui/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     env_file:
       - .env.docker
     ports:
-      - '3000:3000'
+      - '127.0.0.1:3000:3000'
     volumes:
       - ${USER_DIR}:/app/user
     extra_hosts:


### PR DESCRIPTION
Currently the ports of the web ui Docker container are set to `3000:3000`, which sets the external port to run the ip of the host machine. This mean that if the web ui is running on a computer with access to the internet, anyone can access the web ui. To protect EOS users I think it's better to default the external port to locahost.